### PR TITLE
dodx: live CP state natives, InitObj→DLL reorder, DeathMsg handler, pre-push hooks

### DIFF
--- a/modules/dod/dodx/NCP.cpp
+++ b/modules/dod/dodx/NCP.cpp
@@ -285,9 +285,26 @@ static cell AMX_NATIVE_CALL dodx_area_get_data(AMX *amx, cell *params)
 		case CA_axis_numcap:
 			return GET_CA_PD(mObjects.obj[index].pAreaEdict).axis_numcap;
 		case CA_timetocap:
-			return GET_CA_PD(mObjects.obj[index].pAreaEdict).time_to_cap;
+			return GET_CA_PD(mObjects.obj[index].pAreaEdict).cap_time;
 		case CA_can_cap:
 			return GET_CA_PD(mObjects.obj[index].pAreaEdict).can_cap;
+		case CA_num_allies:
+			return GET_CA_PD(mObjects.obj[index].pAreaEdict).num_allies;
+		case CA_num_axis:
+			return GET_CA_PD(mObjects.obj[index].pAreaEdict).num_axis;
+		case CA_is_capturing:
+			return GET_CA_PD(mObjects.obj[index].pAreaEdict).is_capturing;
+		case CA_capturing_team:
+			return GET_CA_PD(mObjects.obj[index].pAreaEdict).capturing_team;
+		case CA_owning_team:
+			return GET_CA_PD(mObjects.obj[index].pAreaEdict).owning_team;
+		case CA_cap_mode:
+			return GET_CA_PD(mObjects.obj[index].pAreaEdict).cap_mode;
+		case CA_time_remaining:
+		{
+			float t = GET_CA_PD(mObjects.obj[index].pAreaEdict).time_remaining;
+			return amx_ftoc(t);
+		}
 
 		// strings
 		case CA_target:
@@ -328,7 +345,7 @@ static cell AMX_NATIVE_CALL dodx_area_set_data(AMX *amx, cell *params)
 			GET_CA_PD(mObjects.obj[index].pAreaEdict).axis_numcap = ivalue;
 			return 1;
 		case CA_timetocap:
-			GET_CA_PD(mObjects.obj[index].pAreaEdict).time_to_cap = ivalue;
+			GET_CA_PD(mObjects.obj[index].pAreaEdict).cap_time = ivalue;
 			return 1;
 		case CA_can_cap:
 			GET_CA_PD(mObjects.obj[index].pAreaEdict).can_cap = ivalue;

--- a/modules/dod/dodx/dodx.h
+++ b/modules/dod/dodx/dodx.h
@@ -241,21 +241,32 @@ struct pd_dca {
 	float angles_y;
 	float angles_z; // 15
 
+	// KTP: block before cap_mode sized so cap_mode lines up with m_iCapMode per gamedata
+	// (offsets-careacapture.txt). Windows m_iCapMode=492, Linux m_iCapMode=512.
+	// Windows pre-block header = 64 bytes -> (492-64)/4 = 107 ints.
+	// Linux pre-block header   = 60 bytes -> (512-60)/4 = 113 ints.
 #if defined(_WIN32)
-	int unknown_block_16[111];
+	int unknown_block_16[107];
 #else
-	int unknown_block_16[116]; // linux +5 more
+	int unknown_block_16[113];
 #endif
 
-	int time_to_cap; // 127
-	int iunk_128;
-	int allies_numcap; // 129
-	int axis_numcap; // 130
+	// Live CAreaCapture state (from gamedata offsets-careacapture.txt).
+	// Reading these is the game's own source of truth — no AABB/radius math.
+	int cap_mode;           // m_iCapMode
+	int is_capturing;       // m_bCapturing (non-zero while a team is progressing a cap)
+	int capturing_team;     // m_nCapturingTeam (1=allies, 2=axis, 0=none)
+	int owning_team;        // m_nOwningTeam
 
-	int iunk_131;
-	int iunk_132;
+	int cap_time;           // m_nCapTime (total seconds to cap; was named time_to_cap)
+	float time_remaining;   // m_fTimeRemaining (seconds left on active cap; was iunk_128)
+	int allies_numcap;      // m_nAlliesNumCap (required count to cap for allies)
+	int axis_numcap;        // m_nAxisNumCap
 
-	int can_cap; // 133 flags : 1-allies can , 256-axis can, default 257 (all can)
+	int num_allies;         // m_nNumAllies (live count of allies in zone; was iunk_131)
+	int num_axis;           // m_nNumAxis (live count of axis in zone; was iunk_132)
+
+	int can_cap;            // m_bAlliesCanCap combined w/ axis (flags: 1=allies, 256=axis)
 
 	int iunk_134;
 	int iunk_135;
@@ -356,6 +367,15 @@ enum CA_VALUE {
 	CA_timetocap,
 	CA_can_cap,
 
+	// Live cap state (read-only). See offsets-careacapture.txt.
+	CA_num_allies,       // m_nNumAllies: players from allies team currently in zone
+	CA_num_axis,         // m_nNumAxis: players from axis team currently in zone
+	CA_is_capturing,     // m_bCapturing: non-zero while a cap is in progress
+	CA_capturing_team,   // m_nCapturingTeam: 1=allies, 2=axis, 0=none
+	CA_owning_team,      // m_nOwningTeam: 1=allies, 2=axis, 0=neutral
+	CA_cap_mode,         // m_iCapMode
+	CA_time_remaining,   // m_fTimeRemaining (float, read via Float:, cast with dodx_area_get_data)
+
 	// strings
 	CA_target,
 	CA_sprite,
@@ -396,6 +416,7 @@ void Client_Object_End(void*);
 void Client_PStatus(void*);
 void Client_InitObj(void*);
 void Client_SetObj(void*);
+void Client_DeathMsg(void*);  // KTP: Suicide / world-kill detection
 
 typedef void (*funEventCall)(void*);
 
@@ -421,6 +442,7 @@ extern int gmsgPStatus;
 extern int gmsgTeamInfo;  // KTP: For scoreboard team name refresh
 extern int gmsgInitObj;   // KTP: CP tracking
 extern int gmsgSetObj;    // KTP: CP tracking
+extern int gmsgDeathMsg;  // KTP: Suicide / world-kill detection (no Damage path)
 
 extern int iFDamage;
 extern int iFDeath;
@@ -440,6 +462,7 @@ extern int iFFlushStats;  // KTP: Forward for stats flush notification
 extern int iFDamagePre;   // KTP: Forward for damage modification (fires before client_damage)
 extern int iFInitCP;      // KTP: Forward for CP init
 extern int iFCPCaptured;  // KTP: Forward for CP ownership change
+extern bool g_cpOrderingFinalized;  // KTP: Has InitObj reordered mObjects to match DLL?
 extern int iFScoreEvent;  // KTP: Forward for enriched score event with CP context
 
 // KTP: Last CP capture tracking (for ObjScore correlation)

--- a/modules/dod/dodx/moduleconfig.cpp
+++ b/modules/dod/dodx/moduleconfig.cpp
@@ -73,6 +73,7 @@ edict_t* g_pFirstEdict = nullptr;
 
 // KTP: Server active flag - prevents message processing during map changes
 bool g_bServerActive = false;
+bool g_cpOrderingFinalized = false;  // KTP: Set true once Client_InitObj has reordered mObjects to match DLL's SetObj id space.
 
 // (g_bCPFromInitObj was removed — entity scan + BSP reorder is the sole CP ordering path)
 
@@ -126,6 +127,7 @@ int gmsgPStatus;
 int gmsgTeamInfo;  // KTP: For scoreboard team name refresh
 int gmsgInitObj;   // KTP: CP tracking
 int gmsgSetObj;    // KTP: CP tracking
+int gmsgDeathMsg;  // KTP: Suicide / world-kill detection (no Damage path)
 
 RankSystem g_rank;
 Grenades g_grenades;
@@ -176,6 +178,7 @@ g_user_msg[] =
 	{ "TeamInfo",	&gmsgTeamInfo,			NULL,					false },  // KTP: For scoreboard refresh
 	{ "InitObj",	&gmsgInitObj,			Client_InitObj,			false },  // KTP: CP tracking
 	{ "SetObj",		&gmsgSetObj,			Client_SetObj,			false },  // KTP: CP tracking
+	{ "DeathMsg",	&gmsgDeathMsg,			Client_DeathMsg,		false },  // KTP: Suicide path
 	{ 0,0,0,false }
 };
 
@@ -1704,6 +1707,7 @@ static void DODX_InitCPFromEntities()
 	MF_Log("[DODX] CP entity scan starting");
 
 	mObjects.Clear();
+	g_cpOrderingFinalized = false;  // KTP: Allow first matching InitObj to reorder mObjects to DLL order
 
 	// Use FindEntityByClassname instead of GETEDICT loop — pfnPEntityOfEntIndex
 	// hangs during OnPluginsLoaded in extension mode, but pfnFindEntityByString is safe.
@@ -1724,8 +1728,10 @@ static void DODX_InitCPFromEntities()
 		mObjects.obj[idx].icon_neutral = cpd.icon_neutral;
 		mObjects.obj[idx].icon_allies = cpd.icon_allies;
 		mObjects.obj[idx].icon_axis = cpd.icon_axis;
-		mObjects.obj[idx].origin_x = cpd.origin_x;
-		mObjects.obj[idx].origin_y = cpd.origin_y;
+		// Read origin from edict vars, not pdata — the pdata origin offsets
+		// are unreliable (observed as (0, world_x) on dod_anzio instead of (world_x, world_y)).
+		mObjects.obj[idx].origin_x = pEdict->v.origin[0];
+		mObjects.obj[idx].origin_y = pEdict->v.origin[1];
 		mObjects.obj[idx].areaflags = 0;
 		mObjects.obj[idx].pAreaEdict = NULL;
 		mObjects.count++;
@@ -1742,6 +1748,20 @@ static void DODX_InitCPFromEntities()
 
 			if (bspCount == mObjects.count)
 			{
+				// Diagnostic: dump entity origins before match attempt
+				for (int oi = 0; oi < mObjects.count; oi++)
+				{
+					edict_t *pe = mObjects.obj[oi].pEdict;
+					const char *tn = pe ? STRING(pe->v.targetname) : "?";
+					MF_Log("[DODX] BSP sort: entity[%d] origin=(%.0f,%.0f) targetname='%s'",
+						oi, mObjects.obj[oi].origin_x, mObjects.obj[oi].origin_y, tn);
+				}
+				for (int bi = 0; bi < bspCount; bi++)
+				{
+					MF_Log("[DODX] BSP sort: bsp[%d] point_index=%d origin=(%.0f,%.0f)",
+						bi, bspCPs[bi].point_index, bspCPs[bi].origin_x, bspCPs[bi].origin_y);
+				}
+
 				// Sort BSP entries by point_index (ascending) — insertion sort for small N
 				for (int i = 1; i < bspCount; i++)
 				{

--- a/modules/dod/dodx/usermsg.cpp
+++ b/modules/dod/dodx/usermsg.cpp
@@ -14,6 +14,13 @@
 
 #include "amxxmodule.h"
 #include "dodx.h"
+#include <string.h>
+
+// KTP: Per-victim "client_death already fired this frame" gate.
+// The Damage hook fires iFDeath when a tracked attacker damages a victim to <=0 HP.
+// DeathMsg always fires (incl. suicide / world-kill / fall). We need DeathMsg to
+// cover the no-Damage cases without double-firing for the normal kill flow.
+static float g_lastDeathReportTime[33] = {0};
 
 void Client_ResetHUD_End(void* mValue)
 {
@@ -321,6 +328,8 @@ void Client_Health_End(void* mValue)
 	{
 		pAttacker->saveKill(mPlayer,weapon,( aim == 1 ) ? 1:0 ,TA);
 		MF_ExecuteForward( iFDeath, pAttacker->index, mPlayer->index, weapon, aim, TA );
+		if (mPlayer->index >= 1 && mPlayer->index < 33)
+			g_lastDeathReportTime[mPlayer->index] = gpGlobals ? gpGlobals->time : 0.0f;
 	}
 }
 
@@ -460,7 +469,21 @@ void Client_Object_End(void* mValue)
 }
 
 // KTP: Control Point tracking - ported from dodfun module
-// Parses InitObj message containing all CP data for the map
+// Parses InitObj message containing all CP data for the map.
+//
+// Two modes of operation, decided in case 0:
+//   1. mObjects.count == 0 — Metamod path. Use InitObj as the sole source.
+//   2. mObjects.count > 0  — Extension-mode path. Entity scan ran first and
+//      populated mObjects (and resolved pAreaEdict pairings via the lazy
+//      GET_CAPTURE_AREA macro). InitObj from the DLL carries the *correct*
+//      cp ordering — entity-scan order isn't guaranteed to match SetObj id.
+//      First matching InitObj (newCount == mObjects.count) reorders mObjects
+//      to DLL order while preserving each CP's resolved pAreaEdict, then
+//      re-fires iFInitCP so the SMA rebuilds its name cache in the new order.
+static objinfo_t s_initObjScanSnapshot[12];  // Saved entity-scan entries for area pairing
+static int s_initObjScanSnapshotCount = 0;
+static bool s_initObjReorderMode = false;    // True while consuming InitObj to reorder
+
 void Client_InitObj(void* mValue)
 {
 	static int num;
@@ -474,21 +497,36 @@ void Client_InitObj(void* mValue)
 	{
 	case 0:
 		num = 0;
+		s_initObjReorderMode = false;
 		{
 			int newCount = *(int*)mValue;
-			// In extension mode, entity scan populates mObjects during SV_ActivateServer.
-			// Post-boot InitObj messages are unreliable (count=0 empty, count=1 partial).
-			// Skip ALL InitObj processing if entity scan already populated data.
+			MF_Log("[DODX] InitObj case 0: newCount=%d mObjects.count=%d finalized=%d",
+				newCount, mObjects.count, g_cpOrderingFinalized ? 1 : 0);
+
 			if (mObjects.count > 0)
 			{
-				mState = 999; // Skip all remaining params (no case matches)
-				return;
+				// Already finalized OR partial/stale message — skip.
+				if (g_cpOrderingFinalized || newCount != mObjects.count)
+				{
+					MF_Log("[DODX] InitObj: skipped (finalized=%d, newCount=%d, existing=%d)",
+						g_cpOrderingFinalized ? 1 : 0, newCount, mObjects.count);
+					mState = 999;
+					return;
+				}
+
+				// Snapshot entity-scan results so we can rebuild pAreaEdict
+				// pairings after reordering.
+				s_initObjScanSnapshotCount = mObjects.count;
+				for (int i = 0; i < s_initObjScanSnapshotCount && i < 12; i++)
+					s_initObjScanSnapshot[i] = mObjects.obj[i];
+				s_initObjReorderMode = true;
+				mObjects.Clear();
 			}
+
 			mObjects.count = newCount;
 		}
 		if (mObjects.count == 0)
 			mObjects.Clear();
-		// Clamp to array size
 		if (mObjects.count > 12)
 			mObjects.count = 12;
 		break;
@@ -534,8 +572,40 @@ void Client_InitObj(void* mValue)
 		num++;
 		if (num == mObjects.count)
 		{
-			// Do NOT sort — InitObj order matches SetObj index system
-			MF_Log("[DODX] InitObj: parsed %d control points from message", mObjects.count);
+			if (s_initObjReorderMode)
+			{
+				// Carry forward each CP's pAreaEdict pairing from the snapshot
+				// (matched by edict pointer — the only stable identifier).
+				for (int i = 0; i < mObjects.count; i++)
+				{
+					for (int j = 0; j < s_initObjScanSnapshotCount; j++)
+					{
+						if (mObjects.obj[i].pEdict &&
+						    mObjects.obj[i].pEdict == s_initObjScanSnapshot[j].pEdict)
+						{
+							mObjects.obj[i].pAreaEdict = s_initObjScanSnapshot[j].pAreaEdict;
+							mObjects.obj[i].areaflags  = s_initObjScanSnapshot[j].areaflags;
+							break;
+						}
+					}
+				}
+
+				g_cpOrderingFinalized = true;
+				s_initObjReorderMode = false;
+				MF_Log("[DODX] InitObj: reordered %d CPs to DLL order", mObjects.count);
+				for (int i = 0; i < mObjects.count; i++)
+				{
+					edict_t *pe = mObjects.obj[i].pEdict;
+					const char *tn = pe ? STRING(pe->v.targetname) : "?";
+					MF_Log("[DODX]   CP[%d] index=%d owner=%d targetname='%s'",
+						i, mObjects.obj[i].index, mObjects.obj[i].owner, tn);
+				}
+			}
+			else
+			{
+				MF_Log("[DODX] InitObj: parsed %d control points from message", mObjects.count);
+			}
+
 			if (iFInitCP >= 0)
 				MF_ExecuteForward(iFInitCP);
 		}
@@ -597,6 +667,69 @@ void Client_PStatus(void* mValue)
 				MF_ExecuteForward(iFSpawnForward, playerIdx);
 			break;
 		}
+	}
+}
+
+// KTP: DeathMsg user message handler.
+// Format: BYTE killer_index, BYTE victim_index, STRING weapon_logname.
+// DeathMsg fires for every death — including suicides via "kill" console,
+// world deaths (fall, drown, kill triggers) where no Damage message is sent.
+// Damage hook already fires iFDeath for normal kills, so dedup against
+// g_lastDeathReportTime to avoid double-firing for the same death.
+void Client_DeathMsg(void* mValue)
+{
+	static int killerIdx;
+	static int victimIdx;
+
+	switch (mState++)
+	{
+	case 0:
+		killerIdx = *(int*)mValue;
+		break;
+	case 1:
+		victimIdx = *(int*)mValue;
+		break;
+	case 2:
+	{
+		const char *weaponName = (const char *)mValue;
+		if (!gpGlobals) break;
+
+		int maxClients = gpGlobals->maxClients;
+		if (maxClients < 1 || maxClients > 32) break;
+
+		if (victimIdx < 1 || victimIdx > maxClients) break;
+
+		// Dedup: skip if Damage hook already fired iFDeath for this victim
+		// in the current frame (within ~0.1s tolerance for engine timing jitter).
+		float now = gpGlobals->time;
+		if (now - g_lastDeathReportTime[victimIdx] < 0.1f)
+			break;
+
+		// Resolve weapon name to wpnindex (matches xmod_get_wpnlogname behavior).
+		int weapon = 0;
+		if (weaponName && weaponName[0])
+		{
+			for (int i = 0; i < DODMAX_WEAPONS; i++)
+			{
+				if (strcmp(weaponName, weaponData[i].logname) == 0)
+				{
+					weapon = i;
+					break;
+				}
+			}
+		}
+
+		// killer 0 (world) is left as-is; the SMA already remaps killer<1 to victim
+		// to mark it as a suicide.
+		if (killerIdx < 0) killerIdx = 0;
+		if (killerIdx > maxClients) killerIdx = 0;
+
+		int aim = 0;   // No hitplace info on DeathMsg
+		int TA = 0;    // Teamkill flag — Damage hook owns the proper detection
+		MF_ExecuteForward(iFDeath, killerIdx, victimIdx, weapon, aim, TA);
+		g_lastDeathReportTime[victimIdx] = now;
+		break;
+	}
 	}
 }
 

--- a/plugins/include/dodx.inc
+++ b/plugins/include/dodx.inc
@@ -511,6 +511,15 @@ enum CA_VALUE {
 	CA_timetocap,
 	CA_can_cap,
 
+	// Live cap state (read-only). Pulled directly from CAreaCapture pvPrivateData.
+	CA_num_allies,       // m_nNumAllies: allies-team players currently in zone
+	CA_num_axis,         // m_nNumAxis: axis-team players currently in zone
+	CA_is_capturing,     // m_bCapturing: non-zero while a cap is in progress
+	CA_capturing_team,   // m_nCapturingTeam: 1=allies, 2=axis, 0=none
+	CA_owning_team,      // m_nOwningTeam: 1=allies, 2=axis, 0=neutral
+	CA_cap_mode,         // m_iCapMode
+	CA_time_remaining,   // m_fTimeRemaining (float; retrieve and cast with Float:)
+
 	// strings
 	CA_target,
 	CA_sprite,

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Install git hooks for this repo. Idempotent — safe to re-run.
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+HOOKS_DIR="$REPO_ROOT/.git/hooks"
+
+install -m 0755 "$REPO_ROOT/scripts/pre-push.sh" "$HOOKS_DIR/pre-push"
+echo "installed: $HOOKS_DIR/pre-push"

--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Pre-push hook for KTPAMXX.
+#
+# A KTPAMXX break silently corrupts every downstream plugin that depends on
+# amxxpc or the runtime (MatchHandler, HLTVRecorder, CvarChecker, our
+# KTPHudObserver, etc.). This hook runs:
+#   1. make build-amxx    — the scripting platform itself compiles
+#   2. make build-plugins — the fresh amxxpc can still compile plugins
+#
+# Step 2 is the bit that catches API-breaking changes (removed natives,
+# renamed forwards, changed signatures).
+#
+# Requires KTPInfrastructure checked out as a sibling directory.
+# Install with: scripts/install-hooks.sh
+# Bypass once  : git push --no-verify
+# Disable      : export KTP_SKIP_PREPUSH=1
+set -euo pipefail
+
+if [[ "${KTP_SKIP_PREPUSH:-0}" == "1" ]]; then
+  echo "[pre-push] KTP_SKIP_PREPUSH=1 — skipping build"
+  exit 0
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+INFRA_DIR="$REPO_ROOT/../KTPInfrastructure"
+
+if [[ ! -d "$INFRA_DIR" ]]; then
+  echo "[pre-push] KTPInfrastructure not found at $INFRA_DIR"
+  echo "[pre-push] Clone it as a sibling dir, or bypass with --no-verify"
+  exit 1
+fi
+
+VERSION="prepush-$(date +%Y%m%d-%H%M%S)"
+
+cd "$INFRA_DIR"
+echo "[pre-push] make build-amxx VERSION=$VERSION"
+echo "[pre-push] (bypass with --no-verify or KTP_SKIP_PREPUSH=1)"
+
+if ! make build-amxx VERSION="$VERSION"; then
+  echo "[pre-push] AMXX BUILD FAILED — push aborted."
+  exit 1
+fi
+
+echo "[pre-push] make build-plugins VERSION=$VERSION"
+if ! make build-plugins VERSION="$VERSION"; then
+  echo "[pre-push] PLUGIN BUILD FAILED — the amxxpc produced by this KTPAMXX"
+  echo "[pre-push] checkout cannot compile downstream plugins."
+  echo "[pre-push] Push aborted. Bypass with --no-verify only if you know why."
+  exit 1
+fi
+
+echo "[pre-push] build OK (artifacts: $INFRA_DIR/artifacts/$VERSION/)"


### PR DESCRIPTION
## Summary

Two related dodx changes plus a pre-push hook scaffold.

### dodx: live CAreaCapture state + DLL-ordered CPs + DeathMsg handler

- **Live CP state from pdata.** Resized `pd_dca.unknown_block_16` so `cap_mode` lines up with `m_iCapMode` per gamedata `offsets-careacapture.txt` (Win=492, Linux=512). Renamed the old `iunk_*` slots to match in-game fields (`cap_mode`, `is_capturing`, `capturing_team`, `owning_team`, `cap_time`, `time_remaining`, `num_allies`, `num_axis`). Exposed via `dodx_area_get_data` with new `CA_*` enum members so plugins (HUD Observer, MatchHandler, HLTV) can read cap state directly from the engine instead of reimplementing AABB/radius math.
- **InitObj → DLL reorder.** Entity-scan order during SV_ActivateServer isn't guaranteed to match the DLL's SetObj id space. The first matching InitObj message (`newCount == mObjects.count` and `!g_cpOrderingFinalized`) now snapshots entity-scan entries, clears `mObjects`, parses the InitObj, and re-pairs each CP's `pAreaEdict` by matching edict pointers. Re-fires `iFInitCP` so SMA plugins rebuild their name cache in DLL order. Stale / partial InitObj messages are skipped.
- **BSP sort diag + pdata origin fix.** In `DODX_InitCPFromEntities` read origin from `pEdict->v.origin` instead of `cpd.origin_x/y` — the pdata origin offsets are unreliable (observed as `(0, world_x)` on dod_anzio) which silently broke BSP `point_index` reorder and mapped CP names to the wrong entity. Added origin logs before the match for future debugging.
- **DeathMsg handler.** The Damage hook fires `iFDeath` only when a tracked attacker damages a victim to ≤0 HP — so it misses `kill` console suicides and world deaths (fall, drown, trigger_hurt). `Client_DeathMsg` now covers those cases, resolves weapon name → wpnindex, and dedups against `g_lastDeathReportTime` so the normal kill flow doesn't double-fire.

### scripts/: pre-push hook

- `scripts/pre-push.sh` runs `make build-amxx` + `make build-plugins` from the sibling `KTPInfrastructure/` before a push is allowed. The plugin build is the critical bit — it catches API-breaking changes (removed natives, renamed forwards, changed signatures) against every downstream plugin.
- `scripts/install-hooks.sh` installs it into `.git/hooks/pre-push`.
- Bypass: `git push --no-verify` or `KTP_SKIP_PREPUSH=1`.

## Test plan

- [x] `make build-amxx` succeeds (verified via pre-push hook on this push)
- [x] `make build-plugins` succeeds — all downstream plugins (KTPMatchHandler, KTPHLTVRecorder, KTPAdminAudit, KTPGrenadeDamage, KTPGrenadeLoadout, KTPPracticeMode, ktp_cvar, ktp_file) compile cleanly against the new dodx API
- [ ] Runtime smoke on Denver 5: verify `dodx_area_get_data(area, CA_num_allies)` returns live counts on dod_anzio
- [ ] Runtime smoke on Denver 5: verify suicide (`kill` console) and fall deaths both fire `client_death` exactly once via the DeathMsg path
- [ ] Runtime smoke on Denver 5: verify CP names map correctly on dod_anzio, dod_flash, dod_caen (the three maps where pdata origin bug had surfaced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)