### PR TITLE
dodx: gate CP-init diagnostic logs, tighten DeathMsg dedup window

### DIFF
--- a/modules/dod/dodx/moduleconfig.cpp
+++ b/modules/dod/dodx/moduleconfig.cpp
@@ -1748,7 +1748,10 @@ static void DODX_InitCPFromEntities()
 
 			if (bspCount == mObjects.count)
 			{
-				// Diagnostic: dump entity origins before match attempt
+#ifdef DODX_DEBUG_CP_INIT
+				// Diagnostic: dump entity origins + BSP entries before match attempt.
+				// Enable via -DDODX_DEBUG_CP_INIT=1 at build time when investigating
+				// CP-ordering issues. Default off in prod to avoid ~12 lines/map noise.
 				for (int oi = 0; oi < mObjects.count; oi++)
 				{
 					edict_t *pe = mObjects.obj[oi].pEdict;
@@ -1761,6 +1764,7 @@ static void DODX_InitCPFromEntities()
 					MF_Log("[DODX] BSP sort: bsp[%d] point_index=%d origin=(%.0f,%.0f)",
 						bi, bspCPs[bi].point_index, bspCPs[bi].origin_x, bspCPs[bi].origin_y);
 				}
+#endif
 
 				// Sort BSP entries by point_index (ascending) — insertion sort for small N
 				for (int i = 1; i < bspCount; i++)

--- a/modules/dod/dodx/usermsg.cpp
+++ b/modules/dod/dodx/usermsg.cpp
@@ -500,8 +500,10 @@ void Client_InitObj(void* mValue)
 		s_initObjReorderMode = false;
 		{
 			int newCount = *(int*)mValue;
+#ifdef DODX_DEBUG_CP_INIT
 			MF_Log("[DODX] InitObj case 0: newCount=%d mObjects.count=%d finalized=%d",
 				newCount, mObjects.count, g_cpOrderingFinalized ? 1 : 0);
+#endif
 
 			if (mObjects.count > 0)
 			{
@@ -593,6 +595,7 @@ void Client_InitObj(void* mValue)
 				g_cpOrderingFinalized = true;
 				s_initObjReorderMode = false;
 				MF_Log("[DODX] InitObj: reordered %d CPs to DLL order", mObjects.count);
+#ifdef DODX_DEBUG_CP_INIT
 				for (int i = 0; i < mObjects.count; i++)
 				{
 					edict_t *pe = mObjects.obj[i].pEdict;
@@ -600,6 +603,7 @@ void Client_InitObj(void* mValue)
 					MF_Log("[DODX]   CP[%d] index=%d owner=%d targetname='%s'",
 						i, mObjects.obj[i].index, mObjects.obj[i].owner, tn);
 				}
+#endif
 			}
 			else
 			{
@@ -700,9 +704,22 @@ void Client_DeathMsg(void* mValue)
 		if (victimIdx < 1 || victimIdx > maxClients) break;
 
 		// Dedup: skip if Damage hook already fired iFDeath for this victim
-		// in the current frame (within ~0.1s tolerance for engine timing jitter).
+		// in the current or last few frames. Damage and DeathMsg normally ship
+		// in the same server frame (both generated during the same SV_RunCmd
+		// pass), so well under 1ms apart. A 33ms window (~4 frames at
+		// sv_maxupdaterate 120) is comfortably beyond expected engine timing
+		// jitter while minimizing the chance of suppressing a legitimate
+		// quick re-death.
+		//
+		// KNOWN LIMITATION: If a damage message races the DeathMsg by >33ms
+		// (e.g. under a server FPS dip), DeathMsg fires first with TA=0 and
+		// the Damage hook's subsequent fire gets suppressed by this guard.
+		// A real teamkill via a world-damage source (grenade, trigger_hurt)
+		// could then be logged as non-TK in HLStatsX. Narrow edge case —
+		// the Damage hook owns real-time TK detection for the >99% normal
+		// kill path. Revisit if stats regressions surface.
 		float now = gpGlobals->time;
-		if (now - g_lastDeathReportTime[victimIdx] < 0.1f)
+		if (now - g_lastDeathReportTime[victimIdx] < 0.033f)
 			break;
 
 		// Resolve weapon name to wpnindex (matches xmod_get_wpnlogname behavior).


### PR DESCRIPTION
## Summary

Polish follow-up to PR #1. Two items surfaced during review:

### 1. Diagnostic log spam gated behind `DODX_DEBUG_CP_INIT`

BSP sort entity+bsp dump in `DODX_InitCPFromEntities` (~12 lines/map load) and the case 0 / per-CP reorder-list logs in `Client_InitObj` fire on every map change across every instance. Fleet-wide that is ~300 extra lines per rotation. Useful while the CP-ordering bug is under investigation, noise in prod once validated.

Gated behind compile-time `#ifdef DODX_DEBUG_CP_INIT`. Default off in prod; enable with `-DDODX_DEBUG_CP_INIT=1` at build when needed.

Kept in prod:
- `[DODX] InitObj: reordered N CPs to DLL order` — one line per map, confirms reorder ran.
- Error-condition logs (`BSP sort failed`, `no entity match`, `BSP CP count mismatch`, `InitObj: skipped`) — rare and important.

(`CVAR_REGISTER` crashes in extension mode per the moduleconfig.cpp:782 comment, so a runtime cvar wasn't viable — compile-time gating is the portable path.)

### 2. DeathMsg dedup window tightened 100ms → 33ms

`Client_DeathMsg` used a 0.1f (100ms = ~12 frames at 120Hz) dedup window against `g_lastDeathReportTime`. The Damage hook and DeathMsg both fire in the same `SV_RunCmd` pass (< 1ms apart). The 100ms window was much wider than needed and risked suppressing a legitimate Damage-hook fire if it raced behind DeathMsg by >0ms — `TA=0` from DeathMsg would lock in for the victim and a real teamkill via world-damage source (grenade, trigger_hurt) could be misreported as non-TK in HLStatsX.

Tightened to 33ms (~4 frames). Added an inline comment documenting the residual edge case (FPS dip > 33ms race) so future stats regressions have context.

## Test plan

- [x] Build: `bash build_linux.sh` — compiles clean.
- [ ] Runtime smoke on Denver 27019: `[DODX] InitObj case 0:` and `[DODX]   CP[N] ...` lines absent from logs under default build, `[DODX] InitObj: reordered N CPs to DLL order` still present once per map change.
- [ ] Runtime smoke: suicide (`kill` console) fires `client_death` exactly once. World kills fire exactly once. Regular weapon kills still fire exactly once via Damage-hook path.

## Deployment

Canary to Denver 5 (port 27019, lowest-traffic instance) tonight with a manual stop/swap/start. Fleet-wide at next nightly restart via `.so.new` staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)