### PR TITLE
scripts: auto-set KTP_PROJECT_ROOT in pre-push hook on Windows

### DIFF
--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -30,6 +30,19 @@ if [[ ! -d "$INFRA_DIR" ]]; then
   exit 1
 fi
 
+# KTPInfrastructure's Makefile passes $KTP_PROJECT_ROOT as the Docker build context.
+# On Windows (git-bash/msys), the default fallback resolves to a broken relative
+# path (observed as "<cwd>/d/Git"), so the build aborts before compiling.
+# Export a forward-slash Windows path (d:/Git) when unset — Docker Desktop accepts it.
+if [[ -z "${KTP_PROJECT_ROOT:-}" ]]; then
+  case "${OSTYPE:-}" in
+    msys*|cygwin*|win32*)
+      export KTP_PROJECT_ROOT="$(cd "$REPO_ROOT/.." && pwd -W)"
+      echo "[pre-push] Windows detected — set KTP_PROJECT_ROOT=$KTP_PROJECT_ROOT"
+      ;;
+  esac
+fi
+
 VERSION="prepush-$(date +%Y%m%d-%H%M%S)"
 
 cd "$INFRA_DIR"


### PR DESCRIPTION
## Summary

Windows devs cloning KTPAMXX alongside KTPInfrastructure hit an immediate pre-push build failure because `KTPInfrastructure`'s Makefile passes `$KTP_PROJECT_ROOT` as the Docker build context and the default fallback resolves to a broken path on git-bash/msys (observed as `<cwd>/d/Git`, not found).

This adds a Windows-detect block to `scripts/pre-push.sh` that auto-exports `KTP_PROJECT_ROOT` to a forward-slash Windows path (`pwd -W`, e.g. `D:/Git`) when unset. No-op on Linux/macOS. Verified locally — hook now runs end-to-end from a clean environment without manual env-var setup.

## Test plan

- [x] Unset `KTP_PROJECT_ROOT`, run `bash scripts/pre-push.sh` from msys → auto-detect fires, build succeeds (exit 0)
- [x] `git push` triggers the hook → Windows-detected message appears, `build OK` reported, push completes
- [ ] Linux dev verifies the `msys*|cygwin*|win32*` case branch is skipped (no-op path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)