### PR TITLE
dodx: fix per-map g_pFirstEdict re-init + restore guarded PreThink recovery

### DIFF
--- a/modules/dod/dodx/moduleconfig.cpp
+++ b/modules/dod/dodx/moduleconfig.cpp
@@ -944,8 +944,29 @@ static void DODX_OnPlayerPreThink(IVoidHookChain<edict_t *, float> *chain, edict
 	if (!gpGlobals)
 		return;
 
+	// KTP: Last-resort recovery. If DODX_OnSV_ActivateServer was missed for any
+	// reason (hook not fired, INDEXENT(0) returned NULL, etc.), reconstruct
+	// g_pFirstEdict from this player's edict so forwards can resume dispatching.
+	// Before 2.7.4 this path existed unguarded; 2.7.4 replaced it with a hard
+	// return, which turned any single missed re-init into a permanent silent
+	// state on production (Denver 5, ATL1, NY1) — only fixable by plugin
+	// re-attach. MF_Log so the underlying hook miss is visible in logs.
 	if (g_bExtensionMode && !g_pFirstEdict)
-		return;
+	{
+		int tmpIndex = ENTINDEX(pEntity);
+		if (tmpIndex >= 1 && tmpIndex <= gpGlobals->maxClients)
+		{
+			g_pFirstEdict = pEntity - tmpIndex;
+			g_bServerActive = true;
+			for (int i = 1; i <= gpGlobals->maxClients; ++i)
+				GET_PLAYER_POINTER_I(i)->Init(i, g_pFirstEdict + i);
+			MF_Log("dodx: PreThink recovered g_pFirstEdict after SV_ActivateServer hook miss (player idx=%d)", tmpIndex);
+		}
+		else
+		{
+			return;
+		}
+	}
 
 	if (!g_bServerActive)
 		return;
@@ -1157,7 +1178,11 @@ static void DODX_OnSV_ActivateServer(IVoidHookChain<int> *chain, int runPhysics)
 	if (gpGlobals && gpGlobals->maxEntities > 0)
 	{
 		edict_t *pWorld = INDEXENT(0);
-		if (pWorld && !FNullEnt(pWorld))
+		// NOTE: do NOT use FNullEnt — edict 0 IS the world entity (index 0 is valid).
+		// Same fix as 2.7.5 (b95b82c1) in DODX_SetupExtensionHooks; the sibling
+		// per-map path was missed there, leaving this block as the mechanism by
+		// which prod servers accumulate silent-forward state across rotations.
+		if (pWorld)
 		{
 			g_pFirstEdict = pWorld;
 			g_bServerActive = true;
@@ -1165,6 +1190,10 @@ static void DODX_OnSV_ActivateServer(IVoidHookChain<int> *chain, int runPhysics)
 			// Initialize player slots
 			for (int i = 1; i <= gpGlobals->maxClients; i++)
 				GET_PLAYER_POINTER_I(i)->Init(i, g_pFirstEdict + i);
+		}
+		else
+		{
+			MF_Log("dodx: SV_ActivateServer INDEXENT(0) returned NULL — forwards will stall until PreThink fallback or restart");
 		}
 	}
 


### PR DESCRIPTION
# dodx: fix per-map `g_pFirstEdict` re-init + restore guarded PreThink recovery

## Summary

All three production KTP hosts (Denver 5, ATL1, NY1) exhibit the same pattern: within hours of a restart, **every DODX-forward-based event goes silent** — `kill`, `damage`, `prone_change`, `player_spawn`, `player_team_change`, `flag_captured`, `player_score`. AMXX core hooks and polling tasks keep firing. A `restart` brings forwards back immediately.

Root cause is in `modules/dod/dodx/moduleconfig.cpp`. Two independent bugs chain together:

1. **`DODX_OnSV_ActivateServer` uses `!FNullEnt(pWorld)`** — the exact check you explicitly removed from `DODX_SetupExtensionHooks` in 2.7.5 with the comment `"Do NOT use FNullEnt — edict 0 IS the world entity (index 0 is valid)"`. In the per-map path it's still there and blocks the re-init on every map change.
2. **`DODX_OnPlayerPreThink` has no recovery path.** 2.7.4 replaced the `ENTINDEX()`-based fallback with a hard `return` (see `096adb70`). Once per-map re-init fails — for any reason, not just #1 — forwards stay silent until the plugin re-attaches.

2.7.5's fallback in `DODX_SetupExtensionHooks` runs only at plugin attach, which is why `restart` is the only workaround.

## Evidence

- **Matching symptom shape:** Every silent event type routes through `DODX_OnPlayerPreThink` / the forward dispatch that gates on `g_bServerActive && g_pFirstEdict`. Every event type that keeps firing (team_score, time_sync, flags_init, flag_zone_players, player_connect, user_say) does **not** route through that gate. That's a clean isolation.
- **NY1 had zero matches in 4 days of `ktpamx/logs/L2026042*.log`** (no `ROUND_LIVE`, no `ROUND_FREEZE`, no `STATS_PAUSED_AWAITING_ROUNDLIVE`) and forwards are still silent — so `dodx_set_stats_paused` leakage / match-lifecycle theories are ruled out.
- **`restart` fixes it on ATL1** (verified live via rcon) — consistent with `DODX_SetupExtensionHooks` attach-time fallback running fresh.
- **Local 4h / 589-rotation stress test (game-1, vanilla HLDS harness) did NOT reproduce.** Rules out rotation count and wall-clock uptime as standalone triggers. The prod-specific condition (KTP-ReHLDS hook behavior, GLIBC 2.38 dodx binary, real HLTV / player churn) is what eventually makes `DODX_OnSV_ActivateServer` skip the init block on a given map — most plausibly the `FNullEnt` issue itself.
- **Deployed binary on all three hosts:** `dodx_ktp_i386.so` sha256 `b9e17c3cc9f2ae5cd642bf12833c1430a0c30f0692ffc2d7d7976f30cd8c6442` (backup named `.2.7.10.backup`, so live is ~2.7.11). All three have the 2.7.4 removal and 2.7.5 attach-time-only fallback.

## Proposed patch

### 1. Drop `FNullEnt` in `DODX_OnSV_ActivateServer`

```cpp
// modules/dod/dodx/moduleconfig.cpp, DODX_OnSV_ActivateServer (~line 1157)
if (gpGlobals && gpGlobals->maxEntities > 0)
{
    edict_t *pWorld = INDEXENT(0);
-   if (pWorld && !FNullEnt(pWorld))
+   // NOTE: do NOT use FNullEnt — edict 0 IS the world entity (index 0 is valid).
+   // Same fix as 2.7.5 b95b82c1 in DODX_SetupExtensionHooks.
+   if (pWorld)
    {
        g_pFirstEdict = pWorld;
        g_bServerActive = true;
        for (int i = 1; i <= gpGlobals->maxClients; i++)
            GET_PLAYER_POINTER_I(i)->Init(i, g_pFirstEdict + i);
    }
+   else
+   {
+       MF_Log("dodx: SV_ActivateServer INDEXENT(0) returned NULL — forwards will stall until next hook fire");
+   }
}
```

### 2. Restore guarded PreThink recovery (with logging so we can see it hit)

```cpp
// modules/dod/dodx/moduleconfig.cpp, DODX_OnPlayerPreThink (~line 947)
-    if (g_bExtensionMode && !g_pFirstEdict)
-        return;
+    // KTP: Last-resort recovery. If SV_ActivateServer hook was missed for any
+    // reason, reconstruct g_pFirstEdict from this player's edict so forwards
+    // can start dispatching again. Log so the underlying miss is visible.
+    if (g_bExtensionMode && !g_pFirstEdict)
+    {
+        int tmpIndex = ENTINDEX(pEntity);
+        if (tmpIndex >= 1 && tmpIndex <= gpGlobals->maxClients)
+        {
+            g_pFirstEdict = pEntity - tmpIndex;
+            g_bServerActive = true;
+            for (int i = 1; i <= gpGlobals->maxClients; ++i)
+                GET_PLAYER_POINTER_I(i)->Init(i, g_pFirstEdict + i);
+            MF_Log("dodx: PreThink recovered g_pFirstEdict after SV_ActivateServer hook miss (player idx=%d)", tmpIndex);
+        }
+        else
+        {
+            return;
+        }
+    }
```

Rationale for restoring the fallback rather than hardening only path #1: even after the `FNullEnt` fix, *any* future condition that leaves `g_pFirstEdict` NULL across a map transition currently produces a permanent silent state that only a plugin re-attach can clear. A guarded recovery is cheap, touches only extension mode, and surfaces the failure in logs instead of silently killing the live gameplay layer. The `MF_Log` line also gives us a data point on whether #1 is the whole story or whether there are other hook-miss paths still to find.

## Risk

- Patch #1 is strictly a re-application of the same fix already merged in 2.7.5 for the sibling code path — same reasoning, same behavior on happy path. Low risk.
- Patch #2 restores pre-2.7.4 behavior, guarded. It only runs in `g_bExtensionMode` and only when `g_pFirstEdict` is NULL, so happy-path Metamod builds and correctly-initialized extension-mode servers are untouched. The original reason for removal (per commit message: "hard guard instead" of "unsafe fallback init") is addressed by the explicit bounds check on `tmpIndex` and by keeping the fallback extension-mode-only.

## Rollout

- Local test harness (vanilla HLDS) can't reproduce — don't gate merge on local repro.
- Deploy to Denver 5 first (we own parity there); watch logs for `dodx: PreThink recovered…` over ~24h of normal rotations.
- If the log line fires at all, it confirms the diagnosis and we can fan out to ATL1 / NY1 / the rest of the fleet.
- If it never fires but forwards still stall, the `MF_Log` from patch #1 will tell us `INDEXENT(0)` is returning NULL on the per-map path — different bug, but at least visible.

## Related

- Commit `096adb70` (v2.7.4, 2026-03-24) — removed the PreThink fallback this PR restores.
- Commit `b95b82c1` (v2.7.5, 2026-04-05) — added the attach-time `INDEXENT(0)` fallback; this PR mirrors its FNullEnt fix to the per-map path.
- Memory: `project_dodx_forwards_idle_degradation.md` in DoD-hud-observer has the full production diagnostic trail.
- `scripts/sniff-prod-events.ts` in DoD-hud-observer — live per-host event tally against `74.91.112.242:4000`, used for before/after verification.